### PR TITLE
Add CI check on FlightExamples UTs

### DIFF
--- a/.github/workflows/ut-flight-examples.yml
+++ b/.github/workflows/ut-flight-examples.yml
@@ -32,4 +32,4 @@ jobs:
         run_unit_tests: true
         build_location: ./FlightExamples
         fprime_location: ./FlightExamples/lib/fprime
-        fprime_version: devel
+        fprime_version: origin/devel

--- a/.github/workflows/ut-flight-examples.yml
+++ b/.github/workflows/ut-flight-examples.yml
@@ -1,0 +1,35 @@
+name: FlightExamples UTs
+
+on:
+  push:
+    branches: [ devel, release/** ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ devel, release/** ]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/actions/spelling/**'
+      - '.github/ISSUE_TEMPLATE/**'
+
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      name: "Checkout Examples repo"
+      with:
+        submodules: false
+    - name: "Overlay nasa/fprime@devel"
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        path: ./FlightExamples/lib/fprime
+    - uses: fprime-community/project-builder@main
+      with:
+        run_unit_tests: true
+        build_location: ./FlightExamples
+        fprime_location: ./FlightExamples/lib/fprime
+        fprime_version: devel

--- a/.github/workflows/ut-flight-examples.yml
+++ b/.github/workflows/ut-flight-examples.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test
+    name: ""
     runs-on: ubuntu-latest
     steps:
 
@@ -29,7 +29,8 @@ jobs:
         submodules: true
         path: ./FlightExamples/lib/fprime
 
-    - uses: fprime-community/project-builder@main
+    - name: "Build & UTs"
+      uses: fprime-community/project-builder@main
       with:
         run_unit_tests: true
         build_location: ./FlightExamples

--- a/.github/workflows/ut-flight-examples.yml
+++ b/.github/workflows/ut-flight-examples.yml
@@ -18,18 +18,19 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      name: "Checkout Examples repo"
-      with:
-        submodules: false
+
+    - name: "Checkout Examples repo"
+      uses: actions/checkout@v4
+
     - name: "Overlay nasa/fprime@devel"
       uses: actions/checkout@v4
       with:
+        repository: nasa/fprime
         submodules: true
         path: ./FlightExamples/lib/fprime
+
     - uses: fprime-community/project-builder@main
       with:
         run_unit_tests: true
         build_location: ./FlightExamples
         fprime_location: ./FlightExamples/lib/fprime
-        fprime_version: origin/devel


### PR DESCRIPTION
Add in a run of UTs on `FlightExamples` using latest `fprime@devel`.

This check is mostly meant for aiding development and review in this repo. There also exists a check in core F´ to make sure fprime-examples doesn't go out of date w.r.t fprime@devel